### PR TITLE
[FIX] Allow adventure cards to be cast

### DIFF
--- a/src/functions/canBeCast.test.ts
+++ b/src/functions/canBeCast.test.ts
@@ -84,6 +84,47 @@ const testCards: Card[] = [
       },
     ],
   },
+  {
+    name: 'Ardenvale Tactician // Dizzying Swoop',
+    colors: ['W'],
+    cmc: 3,
+    mana_cost: '{1}{W}{W} // {1}{W}',
+    image_uri_normal:
+      'https://img.scryfall.com/cards/normal/front/c/7/c7d5e394-8e41-442e-ae97-a478a61e1b9d.jpg?1568302736',
+    scryfall_uri:
+      'https://scryfall.com/card/eld/5/ardenvale-tactician-dizzying-swoop?utm_source=api',
+    type_line: 'Creature — Human Knight // Instant — Adventure',
+    power: '2',
+    toughness: '3',
+    card_faces: [
+      {
+        object: 'card_face',
+        name: 'Ardenvale Tactician',
+        mana_cost: '{1}{W}{W}',
+        type_line: 'Creature — Human Knight',
+        oracle_text: 'Flying',
+        power: '2',
+        toughness: '3',
+        flavor_text:
+          'In a castle that prizes loyalty above all, the bond between knight and griffin is unmatched.',
+        artist: 'Jason Rainville',
+        artist_id: '6ed7e669-579b-443d-b223-e5cbcb2a7483',
+        illustration_id: '627d6163-08a5-40b8-938c-264d01ec29bb',
+      },
+      {
+        object: 'card_face',
+        name: 'Dizzying Swoop',
+        mana_cost: '{1}{W}',
+        type_line: 'Instant — Adventure',
+        oracle_text:
+          'Tap up to two target creatures. (Then exile this card. You may cast the creature later from exile.)',
+        artist: 'Jason Rainville',
+        artist_id: '6ed7e669-579b-443d-b223-e5cbcb2a7483',
+      },
+    ],
+    layout: 'adventure',
+    scryfall_id: 'c7d5e394-8e41-442e-ae97-a478a61e1b9d',
+  },
 ]
 
 const absorbCard = testCards.find((card) => card.name === 'Absorb') as Card
@@ -94,6 +135,10 @@ const incubationIncongruityCard = testCards.find(
 
 const warrantWardenCard = testCards.find(
   (card) => card.name === 'Warrant // Warden',
+) as Card
+
+const ardenvaleTacticianCard = testCards.find((card) =>
+  card.name.includes('Ardenvale Tactician'),
 ) as Card
 
 describe('formatMana function returns a usable manaObject', () => {
@@ -171,6 +216,12 @@ describe('canBeCast determines if card is castable', () => {
     expect(result).toEqual(true)
   })
 
+  test('it returns the correct result for adventure cards', () => {
+    const testCost = '{W}{W}{G}'
+    const result = canBeCast(ardenvaleTacticianCard, testCost)
+    expect(result).toEqual(true)
+  })
+
   // test('calculates with high generic mana', () => {
   //   // works with a hypothetical spell of {10}{R}{W}
   // })
@@ -188,7 +239,7 @@ describe('integration? and other tests', () => {
   test('filtering using canBeCast gives the correct cards', () => {
     const testCost = '{W}{W}{U}{U}'
     const result = testCards.filter((card) => canBeCast(card, testCost))
-    expect(result.length).toEqual(3)
+    expect(result.length).toEqual(4)
   })
 
   test('generateMana can be used with canBeCast', () => {

--- a/src/functions/canBeCast.ts
+++ b/src/functions/canBeCast.ts
@@ -81,10 +81,12 @@ function canBeCast(card: Card, cost: string): boolean {
     const firstFace = card.card_faces[0]
     const secondFace = card.card_faces[1]
     // stop evaluating a face if it isn't instant
-    const firstFaceCastable =
-      firstFace.type_line == 'Instant' ? canBeCast(firstFace, cost) : false
-    const secondFaceCastable =
-      secondFace.type_line == 'Instant' ? canBeCast(secondFace, cost) : false
+    const firstFaceCastable = firstFace.type_line.includes('Instant')
+      ? canBeCast(firstFace, cost)
+      : false
+    const secondFaceCastable = secondFace.type_line.includes('Instant')
+      ? canBeCast(secondFace, cost)
+      : false
     // if one face is castable, then the whole card is valid
     // console.log(firstFaceCastable)
     // console.log(secondFaceCastable)


### PR DESCRIPTION
The logic in canBeCast looked for a match on 'Instant' as type line, and
Adventures have a subtype. The new logic uses `include` to remedy this.